### PR TITLE
fix: delete option also does --delete-excluded

### DIFF
--- a/tasks/up.ansible.yml
+++ b/tasks/up.ansible.yml
@@ -18,12 +18,12 @@
     checksum: true
     owner: false
     group: false
-    delete: true
+    delete: false
     dirs: true
     recursive: true
     rsync_opts: >-
       {{
-        docker_deploy_rsync_opts +
+        ['--delete'] + docker_deploy_rsync_opts +
         (docker_deploy_files |
           selectattr('dest', 'defined') |
           map(attribute='dest') |


### PR DESCRIPTION
Delete option of `ansible.posix.synchronize` also add the flag `--delete-exclude`.