### PR TITLE
chore: update supported distros

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,12 @@ jobs:
       fail-fast: false
       matrix:
         distro:
-          - ubuntu2204
-          - ubuntu2004
-          - ubuntu1804
+          - debian13
           - debian12
           - debian11
-          - debian10
+          - ubuntu2404
+          - ubuntu2204
+          - ubuntu2004
 
     steps:
       - name: Check out the codebase.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,18 +8,18 @@ galaxy_info:
   author: Tinyblargon
   description: Ansible role to deploy a docker compose stack (file).
   license: MIT
-  min_ansible_version: '2.14.1'
+  min_ansible_version: "2.14.1"
   platforms:
     - name: Debian
       versions:
-        - buster
-        - bullseye
+        - trixie
         - bookworm
+        - bullseye
     - name: Ubuntu
       versions:
-        - bionic
-        - focal
+        - noble
         - jammy
+        - focal
   galaxy_tags:
     - docker
     - compose


### PR DESCRIPTION
Adds support for:
- Debian 13
- Ubuntu 24.04

Removes support for:
- Debian 10
- Ubuntu 18.04